### PR TITLE
Fix links to jobs and trello

### DIFF
--- a/dashboards/rdo-dev.erb
+++ b/dashboards/rdo-dev.erb
@@ -27,7 +27,7 @@ $(function() {
     </li>
 
     <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
-      <div data-id="deloreanci" data-view="Alert" data-title="Master RDO Promotion CI" data-addclass-danger="isTooHigh" data-addclass-alert="isHigh" data-suffix="d" data-moreinfo="# of days since successful run" data-link="https://ci.centos.org/view/rdo/view/promotion-pipeline/job/rdo-delorean-promote-master/"></div>
+      <div data-id="deloreanci" data-view="Alert" data-title="Master RDO Promotion CI" data-addclass-danger="isTooHigh" data-addclass-alert="isHigh" data-suffix="d" data-moreinfo="# of days since successful run" data-link="https://ci.centos.org/view/rdo/view/promotion-pipeline/job/rdo_trunk-promote-master-current-tripleo/"></div>
     </li>
     <li data-row="2" data-col="2" data-sizex="1" data-sizey="1">
       <div data-id="deloreanciocata" data-view="Alert" data-title="Ocata RDO Promotion CI" data-addclass-danger="isTooHigh" data-addclass-alert="isHigh" data-suffix="d" data-moreinfo="# of days since successful run" data-link="https://ci.centos.org/view/rdo/view/promotion-pipeline/job/rdo_trunk-promote-ocata-current-tripleo/"></div>
@@ -37,10 +37,10 @@ $(function() {
     </li>
 
     <li data-row="3" data-col="1" data-sizex="1" data-sizey="1">
-      <div data-id="tripleopin" data-view="Alert" data-title="Tripleo Pin Packages Master" data-addclass-danger="isTooHigh" data-addclass-alert="isHigh" data-suffix="d" data-moreinfo="# of days since pinning" data-link="https://etherpad.openstack.org/p/tripleo-ci-status"></div>
+      <div data-id="tripleopin" data-view="Alert" data-title="Tripleo Pin Packages Master" data-addclass-danger="isTooHigh" data-addclass-alert="isHigh" data-suffix="d" data-moreinfo="# of days since pinning" data-link="https://trello.com/b/WXJTwsuU/tripleo-and-rdo-ci-status"></div>
     </li>
     <li data-row="3" data-col="2" data-sizex="1" data-sizey="1">
-      <div data-id="tripleopin-ocata" data-view="Alert" data-title="Tripleo Pin Packages Ocata" data-addclass-danger="isTooHigh" data-addclass-alert="isHigh" data-suffix="d" data-moreinfo="# of days since pinning" data-link="https://etherpad.openstack.org/p/tripleo-ci-status"></div>
+      <div data-id="tripleopin-ocata" data-view="Alert" data-title="Tripleo Pin Packages Ocata" data-addclass-danger="isTooHigh" data-addclass-alert="isHigh" data-suffix="d" data-moreinfo="# of days since pinning" data-link="https://trello.com/b/WXJTwsuU/tripleo-and-rdo-ci-status"></div>
     </li>
     // TODO: Newton
 


### PR DESCRIPTION
RDO promotion master job has wrong name and broken link. Also etherpad is not used anymore, changed links to trello's ones.